### PR TITLE
Fix #45 - Layout shift fix

### DIFF
--- a/src/app/[elementType]/[elementID]/[tab]/_GeneTabs/GeneEQTLs.tsx
+++ b/src/app/[elementType]/[elementID]/[tab]/_GeneTabs/GeneEQTLs.tsx
@@ -70,7 +70,7 @@ const GeneEQTLs = ({ name, id }: GeneEQTLsProps) => {
   }
 
   return (
-    <Grid2 container spacing={3}>
+    <Grid2 container spacing={2}>
       <Grid2 size={12}>
         <DataTable
           columns={[

--- a/src/common/ElementDetails/ElementDetailsHeader.tsx
+++ b/src/common/ElementDetails/ElementDetailsHeader.tsx
@@ -28,7 +28,7 @@ const ElementDetailsHeader = ({elementType, elementID}: ElementDetailsHeaderProp
         {elementID}
       </Typography>
       <Typography>
-        {loading ? <Skeleton width={300} /> : coordinatesDisplay}
+        {loading ? <Skeleton width={215} /> : coordinatesDisplay}
       </Typography>
     </Box>
   )

--- a/src/common/ElementDetails/ElementDetailsLayout.tsx
+++ b/src/common/ElementDetails/ElementDetailsLayout.tsx
@@ -1,28 +1,28 @@
 'use client'
-import { Stack, useMediaQuery, useTheme } from '@mui/material';
+import { Box, Stack, useMediaQuery, useTheme } from '@mui/material';
 import ElementDetailsBreadcrumbs from './ElementDetailsBreadcrumbs';
-import ElementDetailsTabs, { ElementDetailsTabsProps } from './ElementDetailsTabs';
+import ElementDetailsTabs from './ElementDetailsTabs';
 import ElementDetailsHeader, { ElementDetailsHeaderProps } from './ElementDetailsHeader';
 
-export type ElementDetailsLayoutProps = ElementDetailsTabsProps & ElementDetailsHeaderProps & {children: React.ReactNode}
+export type ElementDetailsLayoutProps = ElementDetailsHeaderProps & {children: React.ReactNode}
 
-export default function ElementDetailsLayout(props: ElementDetailsLayoutProps) {
-  const theme = useTheme()
-  const isDesktop = useMediaQuery(theme.breakpoints.up('md'));
+export default function ElementDetailsLayout({elementID, elementType, children}: ElementDetailsLayoutProps) {
   const spaceBetween = 2
 
   return (
-    <Stack height={'100%'} direction={isDesktop ? 'row' : 'column'}>
-      {/* Tabs */}
-      <Stack order={isDesktop ? 1 : 2} sx={!isDesktop && { gap: spaceBetween, m: spaceBetween }}>
-        <ElementDetailsTabs {...props} />
-        {!isDesktop && props.children}
-      </Stack>
-      {/* Header */}
-      <Stack order={isDesktop ? 2 : 1} sx={{ gap: spaceBetween, p: spaceBetween, width: '100%' }}>
+    <Stack height={'100%'} direction={"row"}>
+      {/* Tabs, shown only on desktop */}
+      <Box sx={{display: {xs: "none", md: "initial"}}}>
+        <ElementDetailsTabs elementType={elementType} orientation='vertical' />
+      </Box>
+      <Stack sx={{ width: '100%', p: spaceBetween }} spacing={spaceBetween}>
         <ElementDetailsBreadcrumbs />
-        <ElementDetailsHeader {...props} />
-        {isDesktop && props.children}
+        <ElementDetailsHeader elementType={elementType} elementID={elementID} />
+        {/* Tabs, shown only on mobile */}
+        <Box sx={{ display: { xs: "initial", md: "none" }, borderBottom: 1, borderColor: 'divider' }}>
+          <ElementDetailsTabs elementType={elementType} orientation='horizontal' />
+        </Box>
+        {children}
       </Stack>
     </Stack>
   )

--- a/src/common/ElementDetails/ElementDetailsTabs.tsx
+++ b/src/common/ElementDetails/ElementDetailsTabs.tsx
@@ -9,15 +9,13 @@ import { genePortalTabs, icrePortalTabs, sharedTabs, snpPortalTabs } from "./tab
 
 export type ElementDetailsTabsProps = {
   elementType: GenomicElementType
+  orientation: "horizontal" | "vertical"
 }
 
-const ElementDetailsTabs = ({ elementType }: ElementDetailsTabsProps) => {
+const ElementDetailsTabs = ({ elementType, orientation }: ElementDetailsTabsProps) => {
   const pathname = usePathname();
   const currentTab = pathname.substring(pathname.lastIndexOf('/') + 1);
   const basepath = pathname.substring(0, pathname.lastIndexOf('/'));
-
-  const theme = useTheme();
-  const isDesktop = useMediaQuery(theme.breakpoints.up('md'));
 
   const [value, setValue] = React.useState(currentTab);
 
@@ -51,38 +49,40 @@ const ElementDetailsTabs = ({ elementType }: ElementDetailsTabsProps) => {
     ]
   }, [elementType])
 
+  const horizontalTabs = orientation === "horizontal"
+
   return (
     <Box
       sx={{
-        width: isDesktop ? '250px' : "100%", //clamp width on desktop
-        p: isDesktop ? 2 : 0,
-        background: isDesktop && '#F2F2F2',
-        height: isDesktop ? '100%' : 'inherit'
+        width: { xs: '100%', md: '250px' }, //clamp width on desktop
+        p: { md: 2 },
+        background: { md: '#F2F2F2' },
+        height: { md: '100%'}
       }}
     >
-      {isDesktop &&
-        <Box sx={{mb: 1}}>
-          <Typography variant="h6">
-            Contents
-          </Typography>
-          <Divider />
-        </Box>
-      }
+      <Box sx={{display: {xs: 'none', md: 'initial'}, mb: {xs: 0, md: 1}}}>
+        <Typography variant="h6">
+          Contents
+        </Typography>
+        <Divider />
+      </Box>
       <Tabs
         value={value}
         onChange={handleChange}
         aria-label="SNP Details Tabs"
-        orientation={isDesktop ? 'vertical' : 'horizontal'}
+        orientation={orientation}
+        allowScrollButtonsMobile
         variant="scrollable"
-        scrollButtons="auto"
-        sx={
-          isDesktop && {
-            '& .MuiTab-root': {
-              alignItems: 'flex-start',
-              paddingLeft: 0
-            }
+        scrollButtons={horizontalTabs ? true : "auto"}
+        sx={{
+          '& .MuiTab-root': {
+            alignItems: { md: 'flex-start' },
+            paddingLeft: { md: 0 }
+          },
+          '& .MuiTabs-scrollButtons.Mui-disabled': {
+            opacity: 0.3
           }
-        }
+        }}
       >
         {tabs.map((tab) => 
           <Tab


### PR DESCRIPTION
Fix #45 

Reworks layout and tabs components to eliminate layout shift on both mobile and desktop. Children are now only called in one place in layout which preserves it's state on resize to mobile layout