### PR TITLE
DataGridPro, Sync bar plots to table, fix menu close behavior

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@mui/material": "^6",
     "@mui/material-nextjs": "^6",
     "@mui/x-data-grid": "^7.27.3",
+    "@mui/x-data-grid-pro": "^7.28.1",
     "@types/node": "^22",
     "@types/react": "^18",
     "@types/react-dom": "^18",

--- a/src/app/[elementType]/[elementID]/[tab]/TwoPaneLayout.tsx
+++ b/src/app/[elementType]/[elementID]/[tab]/TwoPaneLayout.tsx
@@ -1,5 +1,5 @@
-import { CloseFullscreenRounded, ExpandMore, MinimizeRounded, TableChartRounded } from "@mui/icons-material"
-import { Stack, Accordion, AccordionSummary, AccordionDetails, Box, Typography, Tabs, Tab, useMediaQuery, useTheme, Grid2 as Grid, IconButton, Tooltip, Button } from "@mui/material"
+import { BarChart, CloseFullscreenRounded, TableChartRounded } from "@mui/icons-material"
+import { Stack, Box, Typography, Tabs, Tab, TabOwnProps, IconButton, TooltipClassKey, Tooltip } from "@mui/material"
 import { useState } from "react"
 
 /**
@@ -9,6 +9,7 @@ export type TwoPaneLayoutProps = {
   TableComponent: React.ReactNode
   plots: {
     tabTitle: string,
+    icon?: TabOwnProps["icon"]
     plotComponent: React.ReactNode
   }[]
 }
@@ -25,48 +26,55 @@ const TwoPaneLayout = ({ TableComponent, plots }: TwoPaneLayoutProps) => {
     setTableOpen(!tableOpen)
   }
 
-  const plotTabs = plots.map(x => x.tabTitle)
+  const plotTabs = plots.map(x => { return { tabTitle: x.tabTitle, icon: x.icon } })
   const figures = plots.map(x => x.plotComponent)
 
+  const TableIconButton = () => {
+    return (
+      <Tooltip title={`${tableOpen ? "Hide" : "Show"} Table`}>
+        {/* Using negative margin instead of 'edge' prop since, edge gives -12px padding instead of needed -8px for actual alignment */}
+        <IconButton onClick={handleToggleTable} sx={{ mx: -1 }}>
+          <TableChartRounded color="primary" />
+        </IconButton>
+      </Tooltip>
+    )
+  }
+
   return (
-    <Stack spacing={2} direction={{xs: "column", lg: "row"}} id="two-pane-layout">
-      <Box flexGrow={0} width={{xs: '100%', lg: tableOpen ? '35%' : 'initial'}} id="table-container">
-        {tableOpen ?
-          <>
-            <Stack direction={"row"} alignItems={"center"} gap={1} mb={1}>
-              <Tooltip title={`${tableOpen ? "Hide" : "Show"} Table`}>
-                {/* Using negative margin instead of 'edge' prop since, edge gives -12px padding instead of needed -8px for actual alignment */}
-                <IconButton onClick={handleToggleTable} sx={{mx: -1}}>
-                  <TableChartRounded color="primary" />
-                </IconButton>
-              </Tooltip>
-              <Typography variant="h5" sx={{ flexGrow: 1 }}>Table View</Typography>
-              <Tooltip title={`${tableOpen ? "Hide" : "Show"} Table`}>
-                {/* Using negative margin instead of 'edge' prop since, edge gives -12px padding instead of needed -8px for actual alignment */}
-                <IconButton onClick={handleToggleTable} sx={{mx: -1}}>
-                  <CloseFullscreenRounded color="primary" />
-                </IconButton>
-              </Tooltip>
-            </Stack>
-            <div>
-              {TableComponent}
-            </div>
-          </>
-          :
-          <Tooltip title={`${tableOpen ? "Hide" : "Show"} Table`}>
-            {/* Using negative margin instead of 'edge' prop since, edge gives -12px padding instead of needed -8px for actual alignment */}
-            <IconButton onClick={handleToggleTable} sx={{mx: -1}}> 
-              <TableChartRounded color="primary" />
-            </IconButton>
-          </Tooltip>
-        }
-      </Box>
-      <Box flexGrow={1} overflow={"hidden"} id="tabs_figure_container">
-        <Tabs value={tab} onChange={handleSetTab} sx={{mb: 2}} id="plot_tabs">
-          {plotTabs.map((tab, i) =>
-            <Tab label={tab} key={i} />)
+    <Stack spacing={2} direction={{ xs: "column", lg: "row" }} id="two-pane-layout">
+      {tableOpen &&
+        <Box flexGrow={0} width={{ xs: '100%', lg: tableOpen ? '35%' : 'initial' }} id="table-container">
+          <Stack direction={"row"} alignItems={"center"} gap={1} mb={2}>
+            <TableIconButton />
+            <Typography variant="h5" sx={{ flexGrow: 1 }}>
+              Table View
+            </Typography>
+            <Tooltip title={`${tableOpen ? "Hide" : "Show"} Table`}>
+              {/* Using negative margin instead of 'edge' prop since, edge gives -12px padding instead of needed -8px for actual alignment */}
+              <IconButton onClick={handleToggleTable} sx={{ mx: -1 }}>
+                <CloseFullscreenRounded color="primary" />
+              </IconButton>
+            </Tooltip>
+            {/* Used to force this container to have the same height as the below tabs. Prevents layout shift when closing the table */}
+            <Tab sx={{visibility: "hidden", minWidth: 0, px: 0}}/>
+          </Stack>
+          <div>
+            {TableComponent}
+          </div>
+        </Box>
+      }
+      <Box flexGrow={1} id="tabs_figure_container">
+        <Stack direction={"row"} alignItems={"center"} mb={2} gap={2}>
+          {!tableOpen &&
+            <TableIconButton />
           }
-        </Tabs>
+          <Tabs value={tab} onChange={handleSetTab} id="plot_tabs">
+            {plotTabs.map((tab, i) =>
+              // minHeight: 48px is initial value for tabs without icon. With icon it's 72 which is way too tall
+              <Tab label={tab.tabTitle} key={i} icon={tab.icon} iconPosition="start" sx={{minHeight: '48px'}} />)
+            }
+          </Tabs>
+        </Stack>
         {figures.map((Figure, i) =>
           <Box display={tab === i ? "block" : "none"} key={i} id={"figure_container"}>
             {Figure}

--- a/src/app/[elementType]/[elementID]/[tab]/VerticalBarPlot.tsx
+++ b/src/app/[elementType]/[elementID]/[tab]/VerticalBarPlot.tsx
@@ -93,7 +93,7 @@ const VerticalBarPlot = <T,>({
   const spaceOnBottom = 20
 
   // X padding
-  const spaceForCategory = 120
+  const spaceForCategory = 130
   const gapBetweenTextAndBar = 10
 
   /**

--- a/src/app/[elementType]/[elementID]/[tab]/VerticalBarPlot.tsx
+++ b/src/app/[elementType]/[elementID]/[tab]/VerticalBarPlot.tsx
@@ -196,7 +196,7 @@ const VerticalBarPlot = <T,>({
               labelProps={{ dy: -5, fontSize: 14, fontFamily: fontFamily }}
               numTicks={ParentWidth < 700 ? 4 : undefined}
               tickFormat={(value: number, index: number) => {
-                if (index === 0 && cutoffNegativeValues && data.some(d => d.value <= negativeCutoff)) {
+                if (index === 0 && value < 0 && cutoffNegativeValues && data.some(d => d.value <= negativeCutoff)) {
                   return "Low Signal"
                 } else return value.toString()
               }}

--- a/src/app/[elementType]/[elementID]/[tab]/_GeneTabs/_GeneExpression/GeneExpression.tsx
+++ b/src/app/[elementType]/[elementID]/[tab]/_GeneTabs/_GeneExpression/GeneExpression.tsx
@@ -5,7 +5,7 @@ import GeneExpressionTable from "./GeneExpressionTable"
 import GeneExpressionUMAP from "./GeneExpressionUMAP"
 import GeneExpressionBarPlot from "./GeneExpressionBarPlot"
 import { BarData } from "../../VerticalBarPlot"
-import { UseGeneExpressionReturn } from "common/hooks/useGeneExpression"
+import { useGeneExpression, UseGeneExpressionReturn } from "common/hooks/useGeneExpression"
 
 
 export type GeneExpressionProps = {
@@ -13,14 +13,19 @@ export type GeneExpressionProps = {
   id: string
 }
 
+export type PointMetadata = UseGeneExpressionReturn["data"][number]
+
 export type SharedGeneExpressionPlotProps = {
   selected: PointMetadata[],
+  geneExpressionData: UseGeneExpressionReturn,
+  sortedFilteredData: PointMetadata[]
 }
-
-export type PointMetadata = UseGeneExpressionReturn["data"][number]
 
 const GeneExpression = ({ name, id }: GeneExpressionProps) => {
   const [selected, setSelected] = useState<PointMetadata[]>([])
+  const [sortedFilteredData, setSortedFilteredData] = useState<PointMetadata[]>([])
+
+  const geneExpressionData = useGeneExpression({ id })
 
   const handlePointsSelected = (pointsInfo: PointMetadata[]) => {
     setSelected([...selected, ...pointsInfo])
@@ -36,12 +41,6 @@ const GeneExpression = ({ name, id }: GeneExpressionProps) => {
     } else setSelected([...selected, bar.metadata])
   }
 
-  /**
-   * In order to make the subset plot work I would need to have some way to capture a 
-   * state that includes the points used to make the subset plot. I think I can use the same state variable 
-   * for highlighting still. Would need to pass
-   */
-
   return (
     <TwoPaneLayout
       TableComponent={
@@ -50,6 +49,9 @@ const GeneExpression = ({ name, id }: GeneExpressionProps) => {
             id={id}
             selected={selected}
             onSelectionChange={handleSelectionChange}
+            sortedFilteredData={sortedFilteredData}
+            setSortedFilteredData={setSortedFilteredData}
+            geneExpressionData={geneExpressionData}
           />
         }
         plots={[
@@ -60,6 +62,8 @@ const GeneExpression = ({ name, id }: GeneExpressionProps) => {
                 name={name}
                 id={id}
                 selected={selected}
+                sortedFilteredData={sortedFilteredData}
+                geneExpressionData={geneExpressionData}
                 onBarClicked={handleBarClick}
               />
           },
@@ -70,6 +74,8 @@ const GeneExpression = ({ name, id }: GeneExpressionProps) => {
                 name={name}
                 id={id}
                 selected={selected}
+                sortedFilteredData={sortedFilteredData}
+                geneExpressionData={geneExpressionData}
                 onSelectionChange={(points) => handlePointsSelected(points.map(x => x.metaData))}
               />
           }

--- a/src/app/[elementType]/[elementID]/[tab]/_GeneTabs/_GeneExpression/GeneExpression.tsx
+++ b/src/app/[elementType]/[elementID]/[tab]/_GeneTabs/_GeneExpression/GeneExpression.tsx
@@ -6,6 +6,7 @@ import GeneExpressionUMAP from "./GeneExpressionUMAP"
 import GeneExpressionBarPlot from "./GeneExpressionBarPlot"
 import { BarData } from "../../VerticalBarPlot"
 import { useGeneExpression, UseGeneExpressionReturn } from "common/hooks/useGeneExpression"
+import { BarChart, ScatterPlot } from "@mui/icons-material"
 
 
 export type GeneExpressionProps = {
@@ -57,6 +58,7 @@ const GeneExpression = ({ name, id }: GeneExpressionProps) => {
         plots={[
           {
             tabTitle: "Bar Plot",
+            icon: <BarChart />,
             plotComponent:
               <GeneExpressionBarPlot
                 name={name}
@@ -69,6 +71,7 @@ const GeneExpression = ({ name, id }: GeneExpressionProps) => {
           },
           {
             tabTitle: "UMAP",
+            icon: <ScatterPlot />,
             plotComponent:
               <GeneExpressionUMAP
                 name={name}

--- a/src/app/[elementType]/[elementID]/[tab]/_GeneTabs/_GeneExpression/GeneExpressionBarPlot.tsx
+++ b/src/app/[elementType]/[elementID]/[tab]/_GeneTabs/_GeneExpression/GeneExpressionBarPlot.tsx
@@ -21,7 +21,7 @@ const GeneExpressionBarPlot = ({name, id, selected, ...rest}: GeneExpressionBarP
         return (
           {
             category: getCellCategoryDisplayname(x.lineage),
-            label: `${x.value.toFixed(2)}, ${x.biosample.slice(0, 30) + (x.biosample.length > 30 ? "..." : "")}`,
+            label: `${x.value.toFixed(2)}, ${x.biosample.slice(0, 23) + (x.biosample.length > 23 ? "..." : "")}`,
             value: x.value,
             id: i.toString(),
             color: (anySelected && isSelected || !anySelected) ? getCellCategoryColor(x.lineage) : '#CCCCCC',

--- a/src/app/[elementType]/[elementID]/[tab]/_GeneTabs/_GeneExpression/GeneExpressionBarPlot.tsx
+++ b/src/app/[elementType]/[elementID]/[tab]/_GeneTabs/_GeneExpression/GeneExpressionBarPlot.tsx
@@ -1,5 +1,4 @@
 import { GeneExpressionProps, PointMetadata, SharedGeneExpressionPlotProps } from "./GeneExpression"
-import { useGeneExpression } from "common/hooks/useGeneExpression"
 import VerticalBarPlot, { BarData, BarPlotProps } from "../../VerticalBarPlot"
 import { useMemo } from "react"
 import { getCellCategoryColor, getCellCategoryDisplayname } from "common/utility"
@@ -9,13 +8,12 @@ export type GeneExpressionBarPlotProps =
   SharedGeneExpressionPlotProps &
   Partial<BarPlotProps<PointMetadata>>
 
-const GeneExpressionBarPlot = ({name, id, selected, ...rest}: GeneExpressionBarPlotProps) => {
-  const { data, loading, error } = useGeneExpression({ id })
+const GeneExpressionBarPlot = ({name, id, selected, sortedFilteredData, ...rest}: GeneExpressionBarPlotProps) => {
 
   const plotData: BarData<PointMetadata>[] = useMemo(() => {
-    if (!data) return []
+    if (!sortedFilteredData) return []
     return (
-      data.map((x, i) => {
+      sortedFilteredData.map((x, i) => {
         const anySelected = selected.length > 0
         const isSelected = selected.some(y => y.name === x.name)
         return (
@@ -29,8 +27,8 @@ const GeneExpressionBarPlot = ({name, id, selected, ...rest}: GeneExpressionBarP
           }
         )
       })
-    ).sort((a,b) => b.value - a.value)
-  }, [data, selected])
+    )
+  }, [sortedFilteredData, selected])
 
   return(
     <VerticalBarPlot

--- a/src/app/[elementType]/[elementID]/[tab]/_GeneTabs/_GeneExpression/GeneExpressionTable.tsx
+++ b/src/app/[elementType]/[elementID]/[tab]/_GeneTabs/_GeneExpression/GeneExpressionTable.tsx
@@ -93,7 +93,8 @@ const GeneExpressionTable = ({name, id, selected, onSelectionChange}: GeneExpres
         <CircularProgress />
         :
         <DataGrid
-          rows={[...data].sort((a,b) => b.value - a.value)}
+          rows={data}
+          loading={loading}
           columns={columns.map(col => { return { ...col, display: 'flex' } })}
           initialState={{
             pagination: {
@@ -117,7 +118,6 @@ const GeneExpressionTable = ({name, id, selected, onSelectionChange}: GeneExpres
           checkboxSelection
           onRowSelectionModelChange={handleRowSelectionModelChange}
           rowSelectionModel={selected.map(x => x.name)}
-          disableRowSelectionOnClick
           getRowHeight={() => 'auto'}
           getRowId={(row) => row.name}
           keepNonExistentRowsSelected //needed to prevent clearing selections on changing filters

--- a/src/app/[elementType]/[elementID]/[tab]/_GeneTabs/_GeneExpression/GeneExpressionTable.tsx
+++ b/src/app/[elementType]/[elementID]/[tab]/_GeneTabs/_GeneExpression/GeneExpressionTable.tsx
@@ -1,18 +1,20 @@
-import { useGeneExpression } from "common/hooks/useGeneExpression"
-import { GeneExpressionProps, PointMetadata } from "./GeneExpression"
-import { CircularProgress, IconButton, Link } from "@mui/material"
+import { GeneExpressionProps, PointMetadata, SharedGeneExpressionPlotProps } from "./GeneExpression"
+import { IconButton, Link } from "@mui/material"
 import { getCellCategoryDisplayname, getStudyLink } from "common/utility"
-import { DataGrid, GridColDef, GridRowSelectionModel, GridToolbar } from "@mui/x-data-grid"
-import { GRID_CHECKBOX_SELECTION_COL_DEF } from "@mui/x-data-grid"
+import { GridColDef, gridFilteredSortedRowEntriesSelector, GridRowSelectionModel, GridToolbar, useGridApiRef, GRID_CHECKBOX_SELECTION_COL_DEF, DataGridPro } from "@mui/x-data-grid-pro"
 import { OpenInNew } from "@mui/icons-material"
+import { Dispatch, SetStateAction } from "react"
 
-export type GeneExpressionTableProps = GeneExpressionProps & {
+export type GeneExpressionTableProps = 
+GeneExpressionProps & 
+SharedGeneExpressionPlotProps &
+{
   onSelectionChange: (selected: PointMetadata[]) => void,
-  selected: PointMetadata[]
+  setSortedFilteredData: Dispatch<SetStateAction<PointMetadata[]>>
 }
 
-const GeneExpressionTable = ({name, id, selected, onSelectionChange}: GeneExpressionTableProps) => {
-  const { data, loading, error } = useGeneExpression({ id })
+const GeneExpressionTable = ({name, id, selected, onSelectionChange, geneExpressionData, setSortedFilteredData, sortedFilteredData}: GeneExpressionTableProps) => {
+  const { data, loading, error } = geneExpressionData
 
   //This is used to prevent sorting from happening when clicking on the header checkbox
   const StopPropagationWrapper = (params) =>
@@ -87,15 +89,35 @@ const GeneExpressionTable = ({name, id, selected, onSelectionChange}: GeneExpres
     onSelectionChange(selectedRows)
   }
 
+  const apiRef = useGridApiRef()
+
+    const arraysAreEqual = (arr1: PointMetadata[], arr2: PointMetadata[]): boolean => {
+      if (arr1.length !== arr2.length) {
+        return false
+      }
+    
+      for (let i = 0; i < arr1.length; i++) {
+        if (arr1[i].name !== arr2[i].name) {
+          return false
+        }
+      }
+      return true
+    };
+  
+    const handleSync = () => {
+      const rows = gridFilteredSortedRowEntriesSelector(apiRef).map(x => x.model) as PointMetadata[]
+      if (!arraysAreEqual(sortedFilteredData, rows)) {
+        setSortedFilteredData(rows)
+      }
+    }
+
   return (
-    <>
-      {loading ?
-        <CircularProgress />
-        :
-        <DataGrid
-          rows={data}
-          loading={loading}
+        <DataGridPro
+          apiRef={apiRef}
+          rows={data || []}
           columns={columns.map(col => { return { ...col, display: 'flex' } })}
+          loading={loading}
+          pagination
           initialState={{
             pagination: {
               paginationModel: {
@@ -113,16 +135,16 @@ const GeneExpressionTable = ({name, id, selected, onSelectionChange}: GeneExpres
           }}
           sortingOrder={['desc', 'asc', null]}
           slots={{ toolbar: GridToolbar }}
-          slotProps={{ toolbar: { showQuickFilter: true } }}
+          slotProps={{ toolbar: { showQuickFilter: true, sx: {p: 1} } }}
           pageSizeOptions={[10, 25, 50]}
           checkboxSelection
           onRowSelectionModelChange={handleRowSelectionModelChange}
           rowSelectionModel={selected.map(x => x.name)}
-          getRowHeight={() => 'auto'}
           getRowId={(row) => row.name}
+          getRowHeight={() => 'auto'}
           keepNonExistentRowsSelected //needed to prevent clearing selections on changing filters
-        />}
-    </>
+          onStateChange={handleSync}
+        />
   )
 }
 

--- a/src/app/[elementType]/[elementID]/[tab]/_GeneTabs/_GeneExpression/GeneExpressionUMAP.tsx
+++ b/src/app/[elementType]/[elementID]/[tab]/_GeneTabs/_GeneExpression/GeneExpressionUMAP.tsx
@@ -1,6 +1,6 @@
 import { useGeneExpression } from "common/hooks/useGeneExpression"
 import { GeneExpressionProps, PointMetadata, SharedGeneExpressionPlotProps } from "./GeneExpression"
-import { Box, Button, FormControl, InputLabel, MenuItem, Select, SelectChangeEvent, Typography } from "@mui/material"
+import { Box, Button, FormControl, InputLabel, MenuItem, Select, SelectChangeEvent, Stack, Typography } from "@mui/material"
 import { getCellCategoryColor, getCellCategoryDisplayname } from "common/utility"
 import { useMemo, useRef, useState } from "react"
 import { interpolateYlOrRd } from "d3-scale-chromatic";
@@ -13,11 +13,11 @@ export type GeneExpressionUmapProps<T> =
   SharedGeneExpressionPlotProps &
   Partial<ChartProps<T>>
 
-const GeneExpressionUMAP = <T extends PointMetadata>({ name, id, selected, ...rest }: GeneExpressionUmapProps<T>) => {
+const GeneExpressionUMAP = <T extends PointMetadata>({ name, id, selected, geneExpressionData, ...rest }: GeneExpressionUmapProps<T>) => {
   const [colorScheme, setColorScheme] = useState<'expression' | 'lineage'>('expression');
   const [showLegend, setShowLegend] = useState<boolean>(true);
 
-  const { data, loading, error } = useGeneExpression({ id })
+  const { data, loading, error } = geneExpressionData
 
   const handleColorSchemeChange = (
     event: SelectChangeEvent,
@@ -115,9 +115,9 @@ const GeneExpressionUMAP = <T extends PointMetadata>({ name, id, selected, ...re
     )
   }
 
-  return (
-    <Box>
-      <FormControl sx={{ mb: 2 }}>
+  const ColorBySelect = () => {
+    return (
+      <FormControl>
         <InputLabel>Color By</InputLabel>
         <Select
           labelId="demo-simple-select-label"
@@ -125,12 +125,18 @@ const GeneExpressionUMAP = <T extends PointMetadata>({ name, id, selected, ...re
           value={colorScheme}
           label="Color By"
           onChange={handleColorSchemeChange}
-          MenuProps={{disableScrollLock: true}}
+          MenuProps={{ disableScrollLock: true }}
         >
           <MenuItem value={"expression"}>Expression</MenuItem>
           <MenuItem value={"lineage"}>Lineage</MenuItem>
         </Select>
       </FormControl>
+    )
+  }
+
+  return (
+    <Stack spacing={2}>
+      <ColorBySelect />
       <Box padding={1} sx={{ border: '1px solid', borderColor: 'divider', borderRadius: 1, position: "relative" }} ref={graphContainerRef}>
         <ParentSize>
           {({ width, height }) => {
@@ -205,7 +211,7 @@ const GeneExpressionUMAP = <T extends PointMetadata>({ name, id, selected, ...re
             )}
           </Box>
       )}
-    </Box>
+    </Stack>
   )
 }
 

--- a/src/app/[elementType]/[elementID]/[tab]/_GeneTabs/_GeneExpression/GeneExpressionUMAP.tsx
+++ b/src/app/[elementType]/[elementID]/[tab]/_GeneTabs/_GeneExpression/GeneExpressionUMAP.tsx
@@ -117,7 +117,7 @@ const GeneExpressionUMAP = <T extends PointMetadata>({ name, id, selected, geneE
 
   const ColorBySelect = () => {
     return (
-      <FormControl>
+      <FormControl sx={{alignSelf: "flex-start"}}>
         <InputLabel>Color By</InputLabel>
         <Select
           labelId="demo-simple-select-label"

--- a/src/app/[elementType]/[elementID]/[tab]/_IcreTabs/_IcreActivity/IcreActivity.tsx
+++ b/src/app/[elementType]/[elementID]/[tab]/_IcreTabs/_IcreActivity/IcreActivity.tsx
@@ -6,6 +6,7 @@ import { IcreActivityAssay, useIcreActivity, UseIcreActivityReturn } from "commo
 import IcreActivityBarPlot from "./IcreActivityBarPlot"
 import { FormControl, FormLabel, FormControlLabel, FormGroup, Checkbox } from "@mui/material"
 import IcreActivityUMAP from "./IcreActivityUMAP"
+import { BarChart, ScatterPlot } from "@mui/icons-material"
 
 
 export type IcreActivityProps = {
@@ -55,6 +56,7 @@ const IcreActivity = ({ accession }: IcreActivityProps) => {
       plots={[
         {
           tabTitle: "Bar Plot",
+          icon: <BarChart />,
           plotComponent:
             <IcreActivityBarPlot
               accession={accession}
@@ -66,6 +68,7 @@ const IcreActivity = ({ accession }: IcreActivityProps) => {
         },
         {
           tabTitle: "UMAP",
+          icon: <ScatterPlot />,
           plotComponent:
             <IcreActivityUMAP
               accession={accession}

--- a/src/app/[elementType]/[elementID]/[tab]/_IcreTabs/_IcreActivity/IcreActivity.tsx
+++ b/src/app/[elementType]/[elementID]/[tab]/_IcreTabs/_IcreActivity/IcreActivity.tsx
@@ -1,8 +1,8 @@
 import TwoPaneLayout from "../../TwoPaneLayout"
-import { useState } from "react"
+import { useEffect, useState } from "react"
 import { BarData } from "../../VerticalBarPlot"
 import IcreActivityTable from "./IcreActivityTable"
-import { IcreActivityAssay, UseIcreActivityReturn } from "common/hooks/useIcreActivity"
+import { IcreActivityAssay, useIcreActivity, UseIcreActivityReturn } from "common/hooks/useIcreActivity"
 import IcreActivityBarPlot from "./IcreActivityBarPlot"
 import { FormControl, FormLabel, FormControlLabel, FormGroup, Checkbox } from "@mui/material"
 import IcreActivityUMAP from "./IcreActivityUMAP"
@@ -16,12 +16,15 @@ export type PointMetadata = UseIcreActivityReturn["data"][number]
 
 export type SharedIcreActivityPlotProps = {
   selected: PointMetadata[],
-  assays: IcreActivityAssay[]
+  iCREActivitydata: UseIcreActivityReturn,
+  sortedFilteredData: PointMetadata[]
 }
 
 const IcreActivity = ({ accession }: IcreActivityProps) => {
   const [selected, setSelected] = useState<PointMetadata[]>([])
-  const [assays, setAssays] = useState<IcreActivityAssay[]>(['ATAC', 'DNase'])
+  const [sortedFilteredData, setSortedFilteredData] = useState<PointMetadata[]>([])
+
+  const iCREActivitydata = useIcreActivity({ accession, assays: ['ATAC', 'DNase'] })
 
   const handlePointsSelected = (pointsInfo: PointMetadata[]) => {
     setSelected([...selected, ...pointsInfo])
@@ -37,36 +40,17 @@ const IcreActivity = ({ accession }: IcreActivityProps) => {
     } else setSelected([...selected, bar.metadata])
   }
 
-  const handleAssayToggle = (assayToToggle: IcreActivityAssay) => {
-    if (assays.includes(assayToToggle) && assays.length > 1) {
-      setAssays(assays.filter(x => x !== assayToToggle))
-    } else if (!assays.includes(assayToToggle)) {
-      setAssays([...assays, assayToToggle])
-    }
-  }
-
-  const AssayRadioButtons = () => {
-    return (
-      <FormControl>
-        <FormLabel id='assay-radio-buttons'>Assay</FormLabel>
-        <FormGroup row>
-          <FormControlLabel control={<Checkbox checked={assays.includes('ATAC')} onChange={() => handleAssayToggle('ATAC')}/>} label="ATAC" />
-          <FormControlLabel control={<Checkbox checked={assays.includes('DNase')} onChange={() => handleAssayToggle('DNase')} />} label="DNase" />
-        </FormGroup>
-      </FormControl>
-    )
-  }
-
   return (
     <>
-      <AssayRadioButtons />
       <TwoPaneLayout
         TableComponent={
           <IcreActivityTable
             accession={accession}
             onSelectionChange={handleSelectionChange}
+            sortedFilteredData={sortedFilteredData}
+            setSortedFilteredData={setSortedFilteredData}
+            iCREActivitydata={iCREActivitydata}
             selected={selected}
-            assays={assays}
           />
         }
         plots={[
@@ -75,8 +59,9 @@ const IcreActivity = ({ accession }: IcreActivityProps) => {
             plotComponent:
               <IcreActivityBarPlot
                 accession={accession}
+                sortedFilteredData={sortedFilteredData}
+                iCREActivitydata={iCREActivitydata}
                 selected={selected}
-                assays={assays}
                 onBarClicked={handleBarClick}
               />
           },
@@ -85,7 +70,8 @@ const IcreActivity = ({ accession }: IcreActivityProps) => {
             plotComponent:
               <IcreActivityUMAP
                 accession={accession}
-                assays={assays}
+                sortedFilteredData={sortedFilteredData}
+                iCREActivitydata={iCREActivitydata}
                 selected={selected}
                 onSelectionChange={(points) => handlePointsSelected(points.map(x => x.metaData))}
               />

--- a/src/app/[elementType]/[elementID]/[tab]/_IcreTabs/_IcreActivity/IcreActivity.tsx
+++ b/src/app/[elementType]/[elementID]/[tab]/_IcreTabs/_IcreActivity/IcreActivity.tsx
@@ -41,44 +41,42 @@ const IcreActivity = ({ accession }: IcreActivityProps) => {
   }
 
   return (
-    <>
-      <TwoPaneLayout
-        TableComponent={
-          <IcreActivityTable
-            accession={accession}
-            onSelectionChange={handleSelectionChange}
-            sortedFilteredData={sortedFilteredData}
-            setSortedFilteredData={setSortedFilteredData}
-            iCREActivitydata={iCREActivitydata}
-            selected={selected}
-          />
+    <TwoPaneLayout
+      TableComponent={
+        <IcreActivityTable
+          accession={accession}
+          selected={selected}
+          onSelectionChange={handleSelectionChange}
+          sortedFilteredData={sortedFilteredData}
+          setSortedFilteredData={setSortedFilteredData}
+          iCREActivitydata={iCREActivitydata}
+        />
+      }
+      plots={[
+        {
+          tabTitle: "Bar Plot",
+          plotComponent:
+            <IcreActivityBarPlot
+              accession={accession}
+              selected={selected}
+              sortedFilteredData={sortedFilteredData}
+              iCREActivitydata={iCREActivitydata}
+              onBarClicked={handleBarClick}
+            />
+        },
+        {
+          tabTitle: "UMAP",
+          plotComponent:
+            <IcreActivityUMAP
+              accession={accession}
+              sortedFilteredData={sortedFilteredData}
+              iCREActivitydata={iCREActivitydata}
+              selected={selected}
+              onSelectionChange={(points) => handlePointsSelected(points.map(x => x.metaData))}
+            />
         }
-        plots={[
-          {
-            tabTitle: "Bar Plot",
-            plotComponent:
-              <IcreActivityBarPlot
-                accession={accession}
-                sortedFilteredData={sortedFilteredData}
-                iCREActivitydata={iCREActivitydata}
-                selected={selected}
-                onBarClicked={handleBarClick}
-              />
-          },
-          {
-            tabTitle: "UMAP",
-            plotComponent:
-              <IcreActivityUMAP
-                accession={accession}
-                sortedFilteredData={sortedFilteredData}
-                iCREActivitydata={iCREActivitydata}
-                selected={selected}
-                onSelectionChange={(points) => handlePointsSelected(points.map(x => x.metaData))}
-              />
-          }
-        ]}
-      />
-    </>
+      ]}
+    />
   )
 }
 

--- a/src/app/[elementType]/[elementID]/[tab]/_IcreTabs/_IcreActivity/IcreActivityBarPlot.tsx
+++ b/src/app/[elementType]/[elementID]/[tab]/_IcreTabs/_IcreActivity/IcreActivityBarPlot.tsx
@@ -6,11 +6,9 @@ import { getCellCategoryColor, getCellCategoryDisplayname } from "common/utility
 export type IcreActivityBarPlotProps = 
   IcreActivityProps & 
   SharedIcreActivityPlotProps &
-  {
-    onBarClicked: BarPlotProps<PointMetadata>["onBarClicked"],
-  }
+  Partial<BarPlotProps<PointMetadata>>
 
-const IcreActivityBarPlot = ({accession, selected, onBarClicked, sortedFilteredData}: IcreActivityBarPlotProps) => {
+const IcreActivityBarPlot = ({accession, selected, sortedFilteredData, ...rest}: IcreActivityBarPlotProps) => {
 
   const plotData: BarData<PointMetadata>[] = useMemo(() => {
     if (!sortedFilteredData) return []
@@ -34,8 +32,8 @@ const IcreActivityBarPlot = ({accession, selected, onBarClicked, sortedFilteredD
 
   return(
     <VerticalBarPlot
+      {...rest}
       data={plotData}
-      onBarClicked={onBarClicked}
       topAxisLabel={`${accession} Z-scores`}
       show95thPercentileLine
       cutoffNegativeValues

--- a/src/app/[elementType]/[elementID]/[tab]/_IcreTabs/_IcreActivity/IcreActivityBarPlot.tsx
+++ b/src/app/[elementType]/[elementID]/[tab]/_IcreTabs/_IcreActivity/IcreActivityBarPlot.tsx
@@ -2,28 +2,26 @@ import { IcreActivityProps, PointMetadata, SharedIcreActivityPlotProps } from ".
 import VerticalBarPlot, { BarData, BarPlotProps } from "../../VerticalBarPlot"
 import { useMemo } from "react"
 import { getCellCategoryColor, getCellCategoryDisplayname } from "common/utility"
-import { useIcreActivity } from "common/hooks/useIcreActivity"
 
 export type IcreActivityBarPlotProps = 
   IcreActivityProps & 
   SharedIcreActivityPlotProps &
   {
-    onBarClicked: BarPlotProps<PointMetadata>["onBarClicked"]
+    onBarClicked: BarPlotProps<PointMetadata>["onBarClicked"],
   }
 
-const IcreActivityBarPlot = ({accession, selected, assays, onBarClicked}: IcreActivityBarPlotProps) => {
-  const { data, loading, error } = useIcreActivity({ accession, assays })
+const IcreActivityBarPlot = ({accession, selected, onBarClicked, sortedFilteredData}: IcreActivityBarPlotProps) => {
 
   const plotData: BarData<PointMetadata>[] = useMemo(() => {
-    if (!data) return []
+    if (!sortedFilteredData) return []
     return (
-      data.map((x, i) => {
+      sortedFilteredData.map((x, i) => {
         const anySelected = selected.length > 0
         const isSelected = selected.some(y => y.name === x.name)
         return (
           {
             category: getCellCategoryDisplayname(x.lineage),
-            label: `${x.value.toFixed(2)}, ${x.biosample.slice(0, 30) + (x.biosample.length > 30 ? "..." : "")}`,
+            label: `${x.value.toFixed(2)}, ${x.biosample.slice(0, 23) + (x.biosample.length > 23 ? "..." : "")}`,
             value: x.value,
             id: i.toString(),
             color: (anySelected && isSelected || !anySelected) ? getCellCategoryColor(x.lineage) : '#CCCCCC',
@@ -31,14 +29,14 @@ const IcreActivityBarPlot = ({accession, selected, assays, onBarClicked}: IcreAc
           }
         )
       })
-    ).sort((a,b) => b.value - a.value)
-  }, [data, selected])
+    )
+  }, [selected, sortedFilteredData])
 
   return(
     <VerticalBarPlot
       data={plotData}
       onBarClicked={onBarClicked}
-      topAxisLabel={`${accession} ${assays.length === 2 ? "ATAC & DNase" : assays[0]} Z-scores`}
+      topAxisLabel={`${accession} Z-scores`}
       show95thPercentileLine
       cutoffNegativeValues
     />

--- a/src/app/[elementType]/[elementID]/[tab]/_IcreTabs/_IcreActivity/IcreActivityTable.tsx
+++ b/src/app/[elementType]/[elementID]/[tab]/_IcreTabs/_IcreActivity/IcreActivityTable.tsx
@@ -1,11 +1,11 @@
-import { Button, CircularProgress, IconButton, Link } from "@mui/material"
+import { IconButton, Link } from "@mui/material"
 import { getCellCategoryDisplayname, getStudyLink } from "common/utility"
-import { DataGrid, GridColDef, gridFilteredSortedRowEntriesSelector, gridFilteredSortedRowIdsSelector, GridRowSelectionModel, GridToolbar, useGridApiEventHandler, useGridApiRef } from "@mui/x-data-grid"
-import { GRID_CHECKBOX_SELECTION_COL_DEF } from "@mui/x-data-grid"
+import { DataGridPro, GridColDef, gridFilteredSortedRowEntriesSelector, GridRowSelectionModel, GridToolbar, useGridApiRef, GRID_CHECKBOX_SELECTION_COL_DEF } from "@mui/x-data-grid-pro"
+// import { DataGrid } from "@mui/x-data-grid"
+// import { GRID_CHECKBOX_SELECTION_COL_DEF } from "@mui/x-data-grid"
 import { IcreActivityProps, PointMetadata, SharedIcreActivityPlotProps } from "./IcreActivity"
-import { useIcreActivity, UseIcreActivityReturn } from "common/hooks/useIcreActivity"
 import { OpenInNew } from "@mui/icons-material"
-import { Dispatch, SetStateAction, useCallback, useEffect, useMemo, useState } from "react"
+import { Dispatch, SetStateAction} from "react"
 
 export type IcreActivityTableProps =
   IcreActivityProps &
@@ -119,11 +119,12 @@ const IcreActivityTable = ({ accession, selected, onSelectionChange, iCREActivit
   }
 
   return (
-    <DataGrid
+    <DataGridPro
       apiRef={apiRef}
-      rows={data}
+      rows={data || []}
       columns={columns.map(col => { return { ...col, display: 'flex' } })}
       loading={loading}
+      pagination
       initialState={{
         pagination: {
           paginationModel: {

--- a/src/app/[elementType]/[elementID]/[tab]/_IcreTabs/_IcreActivity/IcreActivityTable.tsx
+++ b/src/app/[elementType]/[elementID]/[tab]/_IcreTabs/_IcreActivity/IcreActivityTable.tsx
@@ -54,7 +54,7 @@ const IcreActivityTable = ({ accession, selected, onSelectionChange, iCREActivit
     {
       field: 'stimulation',
       headerName: 'Stim',
-      valueFormatter: (_, row) => row.stimulation.charAt(0).toUpperCase()
+      valueGetter: (_, row) => row.stimulation.charAt(0).toUpperCase()
     },
     {
       field: 'lineage',
@@ -142,7 +142,7 @@ const IcreActivityTable = ({ accession, selected, onSelectionChange, iCREActivit
       }}
       sortingOrder={['desc', 'asc', null]}
       slots={{ toolbar: GridToolbar }}
-      slotProps={{ toolbar: { showQuickFilter: true } }}
+      slotProps={{ toolbar: { showQuickFilter: true, sx: {p: 1} } }}
       pageSizeOptions={[10, 25, 50]}
       checkboxSelection
       onRowSelectionModelChange={handleRowSelectionModelChange}

--- a/src/app/[elementType]/[elementID]/[tab]/_IcreTabs/_IcreActivity/IcreActivityTable.tsx
+++ b/src/app/[elementType]/[elementID]/[tab]/_IcreTabs/_IcreActivity/IcreActivityTable.tsx
@@ -1,8 +1,6 @@
 import { IconButton, Link } from "@mui/material"
 import { getCellCategoryDisplayname, getStudyLink } from "common/utility"
 import { DataGridPro, GridColDef, gridFilteredSortedRowEntriesSelector, GridRowSelectionModel, GridToolbar, useGridApiRef, GRID_CHECKBOX_SELECTION_COL_DEF } from "@mui/x-data-grid-pro"
-// import { DataGrid } from "@mui/x-data-grid"
-// import { GRID_CHECKBOX_SELECTION_COL_DEF } from "@mui/x-data-grid"
 import { IcreActivityProps, PointMetadata, SharedIcreActivityPlotProps } from "./IcreActivity"
 import { OpenInNew } from "@mui/icons-material"
 import { Dispatch, SetStateAction} from "react"
@@ -96,7 +94,6 @@ const IcreActivityTable = ({ accession, selected, onSelectionChange, iCREActivit
   }
 
   const apiRef = useGridApiRef()
-
 
   const arraysAreEqual = (arr1: PointMetadata[], arr2: PointMetadata[]): boolean => {
     if (arr1.length !== arr2.length) {

--- a/src/app/[elementType]/[elementID]/[tab]/_IcreTabs/_IcreActivity/IcreActivityTable.tsx
+++ b/src/app/[elementType]/[elementID]/[tab]/_IcreTabs/_IcreActivity/IcreActivityTable.tsx
@@ -1,76 +1,77 @@
-import { CircularProgress, IconButton, Link } from "@mui/material"
+import { Button, CircularProgress, IconButton, Link } from "@mui/material"
 import { getCellCategoryDisplayname, getStudyLink } from "common/utility"
-import { DataGrid, GridColDef, GridRowSelectionModel, GridToolbar } from "@mui/x-data-grid"
+import { DataGrid, GridColDef, gridFilteredSortedRowEntriesSelector, gridFilteredSortedRowIdsSelector, GridRowSelectionModel, GridToolbar, useGridApiEventHandler, useGridApiRef } from "@mui/x-data-grid"
 import { GRID_CHECKBOX_SELECTION_COL_DEF } from "@mui/x-data-grid"
 import { IcreActivityProps, PointMetadata, SharedIcreActivityPlotProps } from "./IcreActivity"
-import { useIcreActivity } from "common/hooks/useIcreActivity"
+import { useIcreActivity, UseIcreActivityReturn } from "common/hooks/useIcreActivity"
 import { OpenInNew } from "@mui/icons-material"
+import { Dispatch, SetStateAction, useCallback, useEffect, useMemo, useState } from "react"
 
 export type IcreActivityTableProps =
   IcreActivityProps &
   SharedIcreActivityPlotProps &
   {
-    onSelectionChange: (selected: PointMetadata[]) => void
+    onSelectionChange: (selected: PointMetadata[]) => void,
+    setSortedFilteredData: Dispatch<SetStateAction<PointMetadata[]>>
   }
 
-const IcreActivityTable = ({accession, selected, assays, onSelectionChange}: IcreActivityTableProps) => {
-  
-  const { data, loading, error } = useIcreActivity({ accession, assays })
+const IcreActivityTable = ({ accession, selected, onSelectionChange, iCREActivitydata, setSortedFilteredData, sortedFilteredData }: IcreActivityTableProps) => {
 
-  
+  const {data, loading, error} = iCREActivitydata
+
   //This is used to prevent sorting from happening when clicking on the header checkbox
   const StopPropagationWrapper = (params) =>
     <div id={'StopPropogationWrapper'} onClick={(e) => e.stopPropagation()}>
       <GRID_CHECKBOX_SELECTION_COL_DEF.renderHeader {...params} />
     </div>
 
-// ensure that "field" is accessing a true property of the row
-type TypeSafeColDef<T> = GridColDef & { field: keyof T }; 
+  // ensure that "field" is accessing a true property of the row
+  type TypeSafeColDef<T> = GridColDef & { field: keyof T };
 
-const columns: TypeSafeColDef<PointMetadata>[] = [
-  {
-    ...GRID_CHECKBOX_SELECTION_COL_DEF as TypeSafeColDef<PointMetadata>, //Override checkbox column https://mui.com/x/react-data-grid/row-selection/#custom-checkbox-column
-    width: 60,
-    sortable: true,
-    hideable: false,
-    renderHeader: StopPropagationWrapper
-  },
-  {
-    field: 'biosample',
-    headerName: 'Biosample',
-    width: 200,
-  },
-  {
-    field: 'assay',
-    headerName: 'Assay'
-  },
-  {
-    field: 'value',
-    headerName: 'Z-score',
-    type: 'number',
-    valueFormatter: (value?: number) => value ? value.toFixed(2) : 'null'
-  },
-  {
-    field: 'stimulation',
-    headerName: 'Stim',
-    valueFormatter: (_, row) => row.stimulation.charAt(0).toUpperCase()
-  },
-  {
-    field: 'lineage',
-    headerName: 'Lineage',
-    width: 150,
-    valueGetter: (_, row) => getCellCategoryDisplayname(row.lineage)
-  },
-  {
-    field: 'link',
-    headerName: 'Experiment',
-    width: 80,
-    sortable: false,
-    disableColumnMenu: true,
-    renderCell: (params) => {
-      return (
-        <IconButton href={params.value} target="_blank" size="small">
-            <OpenInNew fontSize="small"/>
+  const columns: TypeSafeColDef<PointMetadata>[] = [
+    {
+      ...GRID_CHECKBOX_SELECTION_COL_DEF as TypeSafeColDef<PointMetadata>, //Override checkbox column https://mui.com/x/react-data-grid/row-selection/#custom-checkbox-column
+      width: 60,
+      sortable: true,
+      hideable: false,
+      renderHeader: StopPropagationWrapper
+    },
+    {
+      field: 'biosample',
+      headerName: 'Biosample',
+      width: 200,
+    },
+    {
+      field: 'assay',
+      headerName: 'Assay'
+    },
+    {
+      field: 'value',
+      headerName: 'Z-score',
+      type: 'number',
+      valueFormatter: (value?: number) => value ? value.toFixed(2) : 'null'
+    },
+    {
+      field: 'stimulation',
+      headerName: 'Stim',
+      valueFormatter: (_, row) => row.stimulation.charAt(0).toUpperCase()
+    },
+    {
+      field: 'lineage',
+      headerName: 'Lineage',
+      width: 150,
+      valueGetter: (_, row) => getCellCategoryDisplayname(row.lineage)
+    },
+    {
+      field: 'link',
+      headerName: 'Experiment',
+      width: 80,
+      sortable: false,
+      disableColumnMenu: true,
+      renderCell: (params) => {
+        return (
+          <IconButton href={params.value} target="_blank" size="small">
+            <OpenInNew fontSize="small" />
           </IconButton>
         )
       }
@@ -88,49 +89,68 @@ const columns: TypeSafeColDef<PointMetadata>[] = [
       }
     },
   ];
-  
+
   const handleRowSelectionModelChange = (ids: GridRowSelectionModel) => {
     const selectedRows = ids.map((id) => data.find((row) => row.name === id));
     onSelectionChange(selectedRows)
   }
 
+  const apiRef = useGridApiRef()
+
+
+  const arraysAreEqual = (arr1: PointMetadata[], arr2: PointMetadata[]): boolean => {
+    if (arr1.length !== arr2.length) {
+      return false
+    }
+  
+    for (let i = 0; i < arr1.length; i++) {
+      if (arr1[i].name !== arr2[i].name) {
+        return false
+      }
+    }
+    return true
+  };
+
+  const handleSync = () => {
+    const rows = gridFilteredSortedRowEntriesSelector(apiRef).map(x => x.model) as PointMetadata[]
+    if (!arraysAreEqual(sortedFilteredData, rows)) {
+      setSortedFilteredData(rows)
+    }
+  }
 
   return (
-    <>
-      {loading ?
-        <CircularProgress />
-        :
-        <DataGrid
-          rows={[...data].sort((a, b) => b.value - a.value)}
-          columns={columns.map(col => { return { ...col, display: 'flex' } })}
-          initialState={{
-            pagination: {
-              paginationModel: {
-                pageSize: 10,
-              },
-            },
-            sorting: {
-              sortModel: [{field: 'value', sort: 'desc'}],
-            },
-            columns: {
-              columnVisibilityModel: {
-                study: false,
-              }
-            }
-          }}
-          sortingOrder={['desc', 'asc', null]}
-          slots={{ toolbar: GridToolbar }}
-          slotProps={{ toolbar: { showQuickFilter: true } }}
-          pageSizeOptions={[10, 25, 50]}
-          checkboxSelection
-          onRowSelectionModelChange={handleRowSelectionModelChange}
-          rowSelectionModel={selected.map(x => x.name)}
-          disableRowSelectionOnClick
-          getRowId={(row) => row.name}
-          getRowHeight={() => 'auto'}
-          keepNonExistentRowsSelected //needed to prevent clearing selections on changing filters
-        />}
-    </>
+    <DataGrid
+      apiRef={apiRef}
+      rows={data}
+      columns={columns.map(col => { return { ...col, display: 'flex' } })}
+      loading={loading}
+      initialState={{
+        pagination: {
+          paginationModel: {
+            pageSize: 10,
+          },
+        },
+        sorting: {
+          sortModel: [{ field: 'value', sort: 'desc' }],
+        },
+        columns: {
+          columnVisibilityModel: {
+            study: false,
+          }
+        }
+      }}
+      sortingOrder={['desc', 'asc', null]}
+      slots={{ toolbar: GridToolbar }}
+      slotProps={{ toolbar: { showQuickFilter: true } }}
+      pageSizeOptions={[10, 25, 50]}
+      checkboxSelection
+      onRowSelectionModelChange={handleRowSelectionModelChange}
+      rowSelectionModel={selected.map(x => x.name)}
+      getRowId={(row) => row.name}
+      getRowHeight={() => 'auto'}
+      keepNonExistentRowsSelected //needed to prevent clearing selections on changing filters
+      onStateChange={handleSync}
+    />
   )
 }
 

--- a/src/app/[elementType]/[elementID]/[tab]/_IcreTabs/_IcreActivity/IcreActivityUMAP.tsx
+++ b/src/app/[elementType]/[elementID]/[tab]/_IcreTabs/_IcreActivity/IcreActivityUMAP.tsx
@@ -1,6 +1,6 @@
 import { Box, Button, Checkbox, FormControl, FormControlLabel, FormGroup, FormLabel, InputLabel, MenuItem, Radio, RadioGroup, Select, SelectChangeEvent, Stack, Typography } from "@mui/material"
 import { getCellCategoryColor, getCellCategoryDisplayname } from "common/utility"
-import { useMemo, useRef, useState } from "react"
+import { useEffect, useMemo, useRef, useState } from "react"
 import { interpolateYlOrRd } from "d3-scale-chromatic";
 import { Point, ScatterPlot, ChartProps } from "@weng-lab/psychscreen-ui-components"
 import { ParentSize } from "@visx/responsive"
@@ -42,6 +42,22 @@ const IcreActivityUMAP = <T extends PointMetadata>({ accession, selected, iCREAc
     },
     ref: graphContainerRef
   };
+
+  //prevent scroll on UMAP
+  useEffect(() => {
+    const handleWheel = (event: WheelEvent) => {
+      if (graphContainerRef.current && graphContainerRef.current.contains(event.target)) {
+        event.preventDefault(); // Prevent page scroll
+        // Your zoom logic here
+      }
+    };
+
+    document.addEventListener("wheel", handleWheel, { passive: false });
+
+    return () => {
+      document.removeEventListener("wheel", handleWheel);
+    };
+  }, []);
 
   //find the max logTPM for the domain fo the gradient
   const maxValue = useMemo(() => {

--- a/src/app/[elementType]/[elementID]/[tab]/_IcreTabs/_IcreActivity/IcreActivityUMAP.tsx
+++ b/src/app/[elementType]/[elementID]/[tab]/_IcreTabs/_IcreActivity/IcreActivityUMAP.tsx
@@ -25,6 +25,13 @@ const IcreActivityUMAP = <T extends PointMetadata>({ accession, selected, iCREAc
   ) => {
     setColorScheme(event.target.value as 'Zscore' | 'lineage');
   };
+
+  const handleAssayChange = (
+    event: SelectChangeEvent,
+  ) => {
+    setAssay(event.target.value as 'ATAC' | 'DNase' | 'Combined');
+  };
+
   const graphContainerRef = useRef(null);
 
   const map = {
@@ -119,43 +126,50 @@ const IcreActivityUMAP = <T extends PointMetadata>({ accession, selected, iCREAc
     )
   }
 
-  const AssayRadioButtons = () => {
+  const AssaySelect = () => {
     return (
       <FormControl>
-        <FormLabel id="assay-radio-buttons-group-label">Assay</FormLabel>
-        <RadioGroup
-          aria-labelledby="assay-radio-buttons-group-label"
-          name="assay-radio-buttons-group"
+        <InputLabel>Assay</InputLabel>
+        <Select
+          labelId="demo-simple-select-label"
+          id="demo-simple-select"
           value={assay}
-          onChange={(_, value) => setAssay(value as "Combined" | "ATAC" | "DNase")}
-          row
+          label="Assay"
+          onChange={handleAssayChange}
+          MenuProps={{ disableScrollLock: true }}
         >
-          <FormControlLabel value="Combined" control={<Radio />} label="Combined" />
-          <FormControlLabel value="ATAC" control={<Radio />} label="ATAC" />
-          <FormControlLabel value="DNase" control={<Radio />} label="DNase" />
-        </RadioGroup>
+          <MenuItem value={"Combined"}>ATAC & DNase</MenuItem>
+          <MenuItem value={"ATAC"}>ATAC</MenuItem>
+          <MenuItem value={"DNase"}>DNase</MenuItem>
+        </Select>
+      </FormControl>
+    )
+  }
+
+  const ColorBySelect = () => {
+    return (
+      <FormControl>
+        <InputLabel>Color By</InputLabel>
+        <Select
+          labelId="demo-simple-select-label"
+          id="demo-simple-select"
+          value={colorScheme}
+          label="Color By"
+          onChange={handleColorSchemeChange}
+          MenuProps={{ disableScrollLock: true }}
+        >
+          <MenuItem value={"Zscore"}>Z-score</MenuItem>
+          <MenuItem value={"lineage"}>Lineage</MenuItem>
+        </Select>
       </FormControl>
     )
   }
 
   return (
-    <Box>
+    <Stack spacing={2}>
       <Stack direction={"row"} spacing={2}>
-        <FormControl sx={{ mb: 2 }}>
-          <InputLabel>Color By</InputLabel>
-          <Select
-            labelId="demo-simple-select-label"
-            id="demo-simple-select"
-            value={colorScheme}
-            label="Color By"
-            onChange={handleColorSchemeChange}
-            MenuProps={{ disableScrollLock: true }}
-          >
-            <MenuItem value={"Zscore"}>Z-score</MenuItem>
-            <MenuItem value={"lineage"}>Lineage</MenuItem>
-          </Select>
-        </FormControl>
-        <AssayRadioButtons />
+        <ColorBySelect />
+        <AssaySelect />
       </Stack>
       <Box padding={1} sx={{ border: '1px solid', borderColor: 'divider', borderRadius: 1, position: "relative" }} ref={graphContainerRef}>
         <ParentSize>
@@ -231,7 +245,7 @@ const IcreActivityUMAP = <T extends PointMetadata>({ accession, selected, iCREAc
             )}
           </Box>
       )}
-    </Box>
+    </Stack>
   )
 }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,6 +6,7 @@ import { theme } from "./theme"
 import { AppRouterCacheProvider } from '@mui/material-nextjs/v13-appRouter';
 import { ApolloWrapper } from "common/apollo/apollo-wrapper"
 import { Suspense } from "react"
+import MuiXLicense from "common/MuiXLicense";
 
 export const metadata = {
   title: "igSCREEN: Search Immune Candidate cis-Regulatory Elements by ENCODE",
@@ -33,6 +34,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             </AppRouterCacheProvider>
           </ApolloWrapper>
         </Suspense>
+        <MuiXLicense />
       </body>
     </html>
   )

--- a/src/common/MuiXLicense.tsx
+++ b/src/common/MuiXLicense.tsx
@@ -1,0 +1,8 @@
+'use client';
+import { LicenseInfo } from '@mui/x-license';
+
+LicenseInfo.setLicenseKey(process.env.NEXT_PUBLIC_MUI_X_LICENSE_KEY);
+
+export default function MuiXLicense() {
+  return null;
+}

--- a/src/common/components/HomeAppBar.tsx
+++ b/src/common/components/HomeAppBar.tsx
@@ -19,7 +19,7 @@ import MenuIcon from "@mui/icons-material/Menu"
 import { useState } from "react";
 import MobileMenu from "./MobileMenu";
 
-type PageInfo = {
+export type PageInfo = {
   pageName: string,
   link: string,
   dropdownID?: number,
@@ -56,7 +56,8 @@ const ResponsiveAppBar = () => {
   const [anchorDropdown0, setAnchorDropdown0] = useState<null | HTMLElement>(null)
   const [anchorDropdown1, setAnchorDropdown1] = useState<null | HTMLElement>(null)
 
-  const toggleDrawer = (open) => () => {
+  const toggleDrawer = (open: boolean) => {
+    console.log("called with: ", open)
     setDrawerOpen(open);
   };
 
@@ -226,7 +227,10 @@ const ResponsiveAppBar = () => {
             <Box display={{ xs: "flex", md: "none" }} alignItems={"center"} gap={2}>
               <IconButton
                 size="large"
-                onClick={toggleDrawer(true)}
+                onClick={() => {
+                  console.log("icon setting drawer open")
+                  toggleDrawer(true)
+                }}
                 color="inherit"
               >
                 <MenuIcon />

--- a/src/common/components/MobileMenu.tsx
+++ b/src/common/components/MobileMenu.tsx
@@ -4,15 +4,28 @@ import { Box, Button, Divider, Drawer, IconButton, List, ListItem } from "@mui/m
 import MuiLink from "@mui/material/Link"
 import AutoComplete from "./autocomplete"
 import Link from "next/link";
+import { PageInfo } from "./HomeAppBar"
 
-export default function MobileMenu({pageLinks, drawerOpen, toggleDrawer}) {
+export type MobileMenuProps = {
+    pageLinks: PageInfo[]
+    drawerOpen: boolean
+    toggleDrawer: (open: boolean) => void
+}
+
+export default function MobileMenu({pageLinks, drawerOpen, toggleDrawer}: MobileMenuProps) {
+    
+    const closeDrawer = () => {
+        console.log("closeDrawer called in MobileMenu")
+        toggleDrawer(false)
+    }
+    
     return (
         <>
-            <Drawer anchor="right" open={drawerOpen} onClose={toggleDrawer(false)}>
+            <Drawer anchor="right" open={drawerOpen} onClose={closeDrawer}>
                 <Box sx={{ width: 400, p: 2 }}>
                     <AutoComplete
                         style={{ width: "100%"}}
-                        onSearchSubmit={toggleDrawer(false)}
+                        closeDrawer={closeDrawer}
                         slots={{
                             button: (
                                 <IconButton sx={{ color: "black" }}>
@@ -32,7 +45,7 @@ export default function MobileMenu({pageLinks, drawerOpen, toggleDrawer}) {
                                 },
                             },
                             button: {
-                                onClick: toggleDrawer(false)
+                                onClick: closeDrawer
                             }
                         }}
                     />
@@ -41,7 +54,7 @@ export default function MobileMenu({pageLinks, drawerOpen, toggleDrawer}) {
                     <List>
                         {pageLinks.slice().reverse().map((page) => (
                             <Box key={page.pageName} sx={{ mb: 1 }}>
-                                <ListItem onClick={toggleDrawer(false)}>
+                                <ListItem onClick={closeDrawer}>
                                     <MuiLink
                                         component={Link}
                                         href={page.link}
@@ -58,7 +71,7 @@ export default function MobileMenu({pageLinks, drawerOpen, toggleDrawer}) {
                                 {page.subPages && (
                                     <List sx={{ pl: 2 }}>
                                         {page.subPages.map((subPage) => (
-                                            <ListItem key={subPage.pageName} sx={{ py: 0 }} onClick={toggleDrawer(false)}>
+                                            <ListItem key={subPage.pageName} sx={{ py: 0 }} onClick={closeDrawer}>
                                                 <MuiLink component={Link} href={subPage.link} sx={{ color: "gray", textTransform: "none" }}>
                                                     {subPage.pageName}
                                                 </MuiLink>

--- a/src/common/components/autocomplete.tsx
+++ b/src/common/components/autocomplete.tsx
@@ -6,15 +6,24 @@ import {
 } from "@weng-lab/psychscreen-ui-components";
 import { useRouter } from "next/navigation";
 
+export type AutoCompleteProps =
+  Partial<GenomeSearchProps> & 
+  {
+    closeDrawer?: () => void
+  }
+
 /**
  * Redirects the user to the a new page based on the search result
  * @param props - The props for the GenomeSearch component
  */
-export default function AutoComplete(props: Partial<GenomeSearchProps>) {
+export default function AutoComplete({closeDrawer, ...props}: AutoCompleteProps) {
   const router = useRouter();
 
   const handleSearchSubmit = (r: Result) => {
-    props.onSearchSubmit?.(r);
+    //needed to trigger closing the mobile menu drawer
+    if (closeDrawer) {
+      closeDrawer()
+    }
 
     let url = "";
     switch (r.type) {
@@ -36,10 +45,16 @@ export default function AutoComplete(props: Partial<GenomeSearchProps>) {
 
   return (
     <GenomeSearch
-    {...props}
+      {...props}
       assembly="GRCh38"
       queries={["Gene", "iCRE", "SNP", "Coordinate"]}
       onSearchSubmit={handleSearchSubmit}
+      //This is needed to prevent the enter key press from triggering the onClick of the Menu IconButton
+      onKeyDown={(e) => {
+        if (e.key === "Enter") {
+          e.preventDefault();
+        }
+      }}
     />
   );
 }


### PR DESCRIPTION
- Uses pro version of DataGrid to allow multiple concurrent filters in gene expression and icre activity pages
- Syncs table state to bar plot in gene expression and iCRE activity pages
- Fixes issue where sometimes the enter key press in mobile menu would be interpreted as a click on the icon to open the menu (probably a focus issue, would keep the menu open on new search)
- Fixes layout shift in gene expression and icre activity when closing the table
- Adds icons to gene expression and icre activity plot tabs
