### PR TITLE
Portal pages layout

### DIFF
--- a/src/app/[elementType]/page.tsx
+++ b/src/app/[elementType]/page.tsx
@@ -68,7 +68,8 @@ export default function PortalPage({
             xs: "column",
             md: "row",
           }}
-          justifyContent={"space-evenly"}
+          justifyContent={"center"}
+          spacing={2}
         >
           {/* Left Panel */}
           <Grid2
@@ -83,12 +84,11 @@ export default function PortalPage({
           >
             <Typography variant="h3">{title} Portal</Typography>
             <Box
-              mb={4}
               display={"flex"}
               flexDirection={"column"}
               alignItems={"flex-start"}
             >
-              <Typography mb={4}>{description}</Typography>
+              <Typography mb={2}>{description}</Typography>
               <GenomeSearch
                 assembly="GRCh38"
                 onSearchSubmit={handleSearchSubmit}
@@ -112,9 +112,9 @@ export default function PortalPage({
             position="relative"
             sx={{
               height: {
-                lg: "600px",
-                md: "400px",
-                xs: "400px",
+                lg: "350px",
+                md: "250px",
+                xs: "200px",
               },
             }}
           >
@@ -131,7 +131,8 @@ export default function PortalPage({
           size={12}
           display="flex"
           flexDirection="row"
-          justifyContent="space-evenly"
+          justifyContent="center"
+          spacing={2}
         >
           {/* MORE CONTENT HERE */}
         </Grid2>

--- a/src/app/[elementType]/page.tsx
+++ b/src/app/[elementType]/page.tsx
@@ -1,34 +1,128 @@
-'use client'
-import { Stack, Typography } from "@mui/material";
+"use client";
+import { Box, Link, Button, Grid2, Typography } from "@mui/material";
 import { GenomeSearch, Result } from "@weng-lab/psychscreen-ui-components";
 import { formatPortal } from "common/utility";
 import { useRouter } from "next/navigation";
 import { isValidGenomicElement } from "types/globalTypes";
+import Image from "next/image";
+import { ArrowForwardIos } from "@mui/icons-material";
 
-export default function PortalPage({ params: {elementType} }: { params: { elementType: string } }) {
+type PortalConfig = {
+  image: string;
+  title: string;
+  description: string;
+};
 
+const geneConfig: PortalConfig = {
+  image: "/assets/gene-bcre.png",
+  title: "Gene",
+  description:
+    "Explore gene expression across immune cell types at bulk and single-cell resolution for 63 cell types across 736 experiments.",
+};
+
+const icreConfig: PortalConfig = {
+  image: "/assets/disease-trait.png",
+  title: "Explore",
+  description:
+    "Explore regulatory element activity (immune cCREs) across immune cell types at bulk and single-cell resolution for 63 cell types across 736 experiments.",
+};
+
+const snpConfig: PortalConfig = {
+  image: "/assets/snp-qtl.png",
+  title: "SNP",
+  description:
+    "Search SNPs of interest and explore their impact on gene expression, chromatin accessibility, transcription factor (TF) binding and other molecular traits in immune cells.",
+};
+
+export default function PortalPage({
+  params: { elementType },
+}: {
+  params: { elementType: string };
+}) {
   if (!isValidGenomicElement(elementType)) {
-    throw new Error("Unknown genomic element type: " + elementType)
+    throw new Error("Unknown genomic element type: " + elementType);
   }
 
-  const router = useRouter()
-    
+  const router = useRouter();
+
   /**
    * The tab that this ends up directing to is configured in next.config.mjs
    */
   const handleSearchSubmit = (result: Result) => {
-    router.push(result.type + "/" + result.title)
-  }
+    router.push(result.type + "/" + result.title);
+  };
+
+  const { image, title, description } =
+    elementType === "gene"
+      ? geneConfig
+      : elementType === "icre"
+      ? icreConfig
+      : snpConfig;
 
   return (
-    <Stack sx={{ p: 4, gap: 4 }}>
-      <Typography variant="h3">{formatPortal(elementType)} Portal</Typography>
-      <GenomeSearch
-        assembly="GRCh38"
-        onSearchSubmit={handleSearchSubmit}
-        queries={[elementType === "gene" ? "Gene" : elementType === "icre" ? "iCRE" : "SNP"]}
-        fullWidth
-      />
-    </Stack>
-  )
+    <Grid2 container marginInline={5} marginTop={5}>
+      <Grid2 size={12} display={"flex"} flexDirection={"column"}>
+        <Typography variant="h3" mb={2}>
+          {title} Portal
+        </Typography>
+        <Grid2
+          size={12}
+          display={"flex"}
+          flexDirection={{
+            xs: "column",
+            md: "row",
+          }}
+          justifyContent={"space-evenly"}
+        >
+          <Grid2
+            size={{
+              xs: 12,
+              md: 4,
+            }}
+            display={"flex"}
+            flexDirection={"column"}
+            justifyContent={"center"}
+            alignItems={"flex-start"}
+          >
+            <Typography mb={4}>{description}</Typography>
+            <GenomeSearch
+              assembly="GRCh38"
+              onSearchSubmit={handleSearchSubmit}
+              queries={[
+                elementType === "gene"
+                  ? "Gene"
+                  : elementType === "icre"
+                  ? "iCRE"
+                  : "SNP",
+              ]}
+              sx={{ width: "100%" }}
+            />
+          </Grid2>
+          <Grid2
+            size={{
+              xs: 12,
+              md: 6,
+            }}
+            position="relative"
+            sx={{ height: "400px" }}
+          >
+            <Image
+              style={{ objectFit: "contain", objectPosition: "center" }}
+              src={image}
+              fill
+              alt={`${title} logo`}
+            />
+          </Grid2>
+        </Grid2>
+        <Grid2
+          size={12}
+          display="flex"
+          flexDirection="row"
+          justifyContent="space-evenly"
+        >
+          {/* MORE CONTENT HERE */}
+        </Grid2>
+      </Grid2>
+    </Grid2>
+  );
 }

--- a/src/app/[elementType]/page.tsx
+++ b/src/app/[elementType]/page.tsx
@@ -62,9 +62,7 @@ export default function PortalPage({
   return (
     <Grid2 container marginInline={5} marginTop={5}>
       <Grid2 size={12} display={"flex"} flexDirection={"column"}>
-        <Typography variant="h3" mb={2}>
-          {title} Portal
-        </Typography>
+        {/* Panel container */}
         <Grid2
           size={12}
           display={"flex"}
@@ -74,37 +72,53 @@ export default function PortalPage({
           }}
           justifyContent={"space-evenly"}
         >
+          {/* Left Panel */}
           <Grid2
             size={{
               xs: 12,
               md: 4,
+              lg: 3,
             }}
             display={"flex"}
             flexDirection={"column"}
-            justifyContent={"center"}
-            alignItems={"flex-start"}
+            justifyContent={"space-evenly"}
           >
-            <Typography mb={4}>{description}</Typography>
-            <GenomeSearch
-              assembly="GRCh38"
-              onSearchSubmit={handleSearchSubmit}
-              queries={[
-                elementType === "gene"
-                  ? "Gene"
-                  : elementType === "icre"
-                  ? "iCRE"
-                  : "SNP",
-              ]}
-              sx={{ width: "100%" }}
-            />
+            <Typography variant="h3">{title} Portal</Typography>
+            <Box
+              mb={4}
+              display={"flex"}
+              flexDirection={"column"}
+              alignItems={"flex-start"}
+            >
+              <Typography mb={4}>{description}</Typography>
+              <GenomeSearch
+                assembly="GRCh38"
+                onSearchSubmit={handleSearchSubmit}
+                queries={[
+                  elementType === "gene"
+                    ? "Gene"
+                    : elementType === "icre"
+                    ? "iCRE"
+                    : "SNP",
+                ]}
+                sx={{ width: "100%" }}
+              />
+            </Box>
           </Grid2>
+          {/* Right Panel */}
           <Grid2
             size={{
               xs: 12,
               md: 6,
             }}
             position="relative"
-            sx={{ height: "400px" }}
+            sx={{
+              height: {
+                lg: "600px",
+                md: "400px",
+                xs: "400px",
+              },
+            }}
           >
             <Image
               style={{ objectFit: "contain", objectPosition: "center" }}
@@ -114,6 +128,7 @@ export default function PortalPage({
             />
           </Grid2>
         </Grid2>
+        {/* Content container */}
         <Grid2
           size={12}
           display="flex"

--- a/src/app/[elementType]/page.tsx
+++ b/src/app/[elementType]/page.tsx
@@ -1,11 +1,9 @@
 "use client";
-import { Box, Link, Button, Grid2, Typography } from "@mui/material";
+import { Box, Grid2, Typography } from "@mui/material";
 import { GenomeSearch, Result } from "@weng-lab/psychscreen-ui-components";
-import { formatPortal } from "common/utility";
+import Image from "next/image";
 import { useRouter } from "next/navigation";
 import { isValidGenomicElement } from "types/globalTypes";
-import Image from "next/image";
-import { ArrowForwardIos } from "@mui/icons-material";
 
 type PortalConfig = {
   image: string;


### PR DESCRIPTION
Created a responsive layout for the portal pages. Displays a title, description, image and the GenomeSearch component that queries the respective portal's element. Also added an empty Grid component at the bottom to hold other content for future expansion.  